### PR TITLE
refactor(header): 카테고리 선택 컴포넌트를 headless 컴포넌트로 리팩토링

### DIFF
--- a/app/(route)/_home/components/Dropdown.tsx
+++ b/app/(route)/_home/components/Dropdown.tsx
@@ -1,0 +1,69 @@
+import { createContext, ReactNode, useContext, useMemo } from 'react'
+
+type DropdownItemProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+type DropdownProps = {
+  isOpen: boolean
+  openDropdown: () => void
+  closeDropdown: () => void
+}
+
+type DropdownWrapperProps = DropdownProps & {
+  children: ReactNode
+}
+
+const DropdownContext = createContext<DropdownProps>({
+  isOpen: false,
+  openDropdown: () => {},
+  closeDropdown: () => {},
+})
+
+export default function DropdowndownWrapper({
+  isOpen,
+  openDropdown,
+  closeDropdown,
+  children,
+}: DropdownWrapperProps) {
+  const value = useMemo(
+    () => ({ isOpen, openDropdown, closeDropdown }),
+    [isOpen, openDropdown, closeDropdown],
+  )
+  return (
+    <DropdownContext.Provider value={value}>
+      {children}
+    </DropdownContext.Provider>
+  )
+}
+
+const Trigger = ({ children, className }: DropdownItemProps) => {
+  const { isOpen, openDropdown, closeDropdown } = useContext(DropdownContext)
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={isOpen ? closeDropdown : openDropdown}
+    >
+      {children}
+    </button>
+  )
+}
+
+const List = ({ children, className }: DropdownItemProps) => {
+  const { isOpen } = useContext(DropdownContext)
+  return isOpen && <ul className={className}> {children}</ul>
+}
+
+const Item = ({ children, className }: DropdownItemProps) => {
+  const { closeDropdown } = useContext(DropdownContext)
+  return (
+    <li role="presentation" className={className} onClick={closeDropdown}>
+      {children}
+    </li>
+  )
+}
+DropdowndownWrapper.Trigger = Trigger
+DropdowndownWrapper.List = List
+DropdowndownWrapper.Item = Item

--- a/app/(route)/_home/components/Dropdown.tsx
+++ b/app/(route)/_home/components/Dropdown.tsx
@@ -27,10 +27,9 @@ export default function DropdowndownWrapper({
   closeDropdown,
   children,
 }: DropdownWrapperProps) {
-  const value = useMemo(
-    () => ({ isOpen, openDropdown, closeDropdown }),
-    [isOpen, openDropdown, closeDropdown],
-  )
+  // eslint-disable-next-line react/jsx-no-constructed-context-values
+  const value = { isOpen, openDropdown, closeDropdown }
+
   return (
     <DropdownContext.Provider value={value}>
       {children}

--- a/app/(route)/_home/components/NavigationBar.tsx
+++ b/app/(route)/_home/components/NavigationBar.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
+import DropdowndownWrapper from '@/app/(route)/_home/components/Dropdown'
 import ROUTES from '@/app/(route)/_home/constants/routes'
 import ListItem from '@/app/components/ListItem'
 
@@ -25,30 +26,29 @@ export default function NavigationBar() {
 
   const selectMainNav = (navPath: string) => {
     setSelectedNavPath(navPath)
-    setOpen(false)
   }
 
   return (
     <div className="h-12 w-full bg-neutral-500 px-5  dark:bg-turquoise-700 xl:flex xl:justify-center">
       <div className="relative flex h-full max-w-7xl xl:w-full">
-        <button
-          type="button"
-          className="mr-3 h-full border-b-4 border-transparent"
-          onClick={() => setOpen((prev) => !prev)}
+        <DropdowndownWrapper
+          isOpen={open}
+          openDropdown={() => setOpen(true)}
+          closeDropdown={() => setOpen(false)}
         >
-          {getSelectedNav(selectedNavPath)?.name}
-          <FontAwesomeIcon
-            icon={faCaretDown}
-            style={{
-              marginLeft: '10px',
-            }}
-          />
-        </button>
-        {open && (
+          <DropdowndownWrapper.Trigger className="mr-3 h-full border-b-4 border-transparent">
+            {getSelectedNav(selectedNavPath)?.name}
+            <FontAwesomeIcon
+              icon={faCaretDown}
+              style={{
+                marginLeft: '10px',
+              }}
+            />
+          </DropdowndownWrapper.Trigger>
           <div className="absolute top-14 rounded bg-neutral-500  dark:bg-turquoise-700">
-            <ul className="p-2">
+            <DropdowndownWrapper.List className="p-2">
               {ROUTES.map((navItem) => (
-                <li
+                <DropdowndownWrapper.Item
                   key={navItem.path}
                   className="rounded  px-3 py-2 hover:bg-neutral-400 dark:hover:bg-turquoise-600"
                 >
@@ -58,12 +58,11 @@ export default function NavigationBar() {
                   >
                     {navItem.name}
                   </button>
-                </li>
+                </DropdowndownWrapper.Item>
               ))}
-            </ul>
+            </DropdowndownWrapper.List>
           </div>
-        )}
-
+        </DropdowndownWrapper>
         <nav className="h-full">
           <ul className="flex h-full">
             {getSelectedNav(selectedNavPath)?.subNav?.map((subNavItem, idx) => (


### PR DESCRIPTION
## 코드 변경 사항
데이터 로직과 UI 로직을 분리한 headless dropdown 컴포넌트를 추가했습니다.
카테고리 선택 컴포넌트를 headless dropdown 컴포넌트로 리팩토링했습니다.
selectMainNav 함수가 담당하는 역할을 단일화하였습니다.

### 변경 이유
목록을 열고 닫는 기능 관련 로직과 UI 로직 분리라는 관심사 분리를 통해 외부 변경에 영향을 받지 않기 위함입니다.
기존에 여러 기능(카테고리 선택 , 드롭다운 닫기)을 담당하는 `selectMainNav`함수의 책임을 단일화(카테고리 선택)하여 사이드 이펙트가 감소하였습니다.

### 구현 방법
context api를 통해 dropdown 컴포넌트 내부에 상태를 공유합니다.
dropdown 내부 컴포넌트는 className을 통해 UI 변경이 이뤄집니다.

### 영향 범위
드롭다운 컴포넌트 내부의 빈번한 리렌더링이 발생하며 별도의 branch로 context api 최적화 리팩토링을 진행할 예정입니다.

## 중점 리뷰 (선택)
적절한 headless 컴포넌트로 구현한 것인지 리뷰 부탁드립니다.



## 반영 브랜치
feature/21-dropdown -> develop
